### PR TITLE
Switch submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tweetnacl/tweetnacl"]
 	path = tweetnacl/tweetnacl
-	url = git@github.com:dominictarr/tweetnacl.git
+	url = https://github.com/dominictarr/tweetnacl.git


### PR DESCRIPTION
Because of this SSH URL you're required to have a SSH key set up on your computer otherwise we cannot fetch MEWwalletKit:
![image](https://user-images.githubusercontent.com/8790386/148239163-6a4bd016-9c54-4de5-9cd4-2862f448fecc.png)

Would be awesome if you can make a 1.0.1 tag after merging